### PR TITLE
Trigger onClosed callback on close()

### DIFF
--- a/wasm/js/webrtc.js
+++ b/wasm/js/webrtc.js
@@ -118,7 +118,7 @@
 				}
 			},
 
-      handleIceStateChange: function(peerConnection, iceConnectionState) {
+			handleIceStateChange: function(peerConnection, iceConnectionState) {
 				if(peerConnection.rtcUserDeleted) return;
 				if(!peerConnection.rtcIceStateChangeCallback) return;
 				var map = {
@@ -228,7 +228,7 @@
 			return type;
 		},
 
-    rtcGetRemoteDescription: function(pc) {
+		rtcGetRemoteDescription: function(pc) {
 			if(!pc) return 0;
 			var peerConnection = WEBRTC.peerConnectionsMap[pc];
 			var remoteDescription = peerConnection.remoteDescription;
@@ -353,6 +353,12 @@
 				.catch(function(err) {
 					console.error(err);
 				});
+		},
+
+		rtcCloseDataChannel: function(dc) {
+			if (!dc) return;
+			var dataChannel = WEBRTC.dataChannelsMap[dc];
+			dataChannel.close();
 		},
 
 		rtcGetDataChannelLabel: function(dc, pBuffer, size) {

--- a/wasm/src/datachannel.cpp
+++ b/wasm/src/datachannel.cpp
@@ -30,6 +30,7 @@
 
 extern "C" {
 extern void rtcDeleteDataChannel(int dc);
+extern void rtcCloseDataChannel(int dc);
 extern int rtcGetDataChannelLabel(int dc, char *buffer, int size);
 extern int rtcGetDataChannelUnordered(int dc);
 extern int rtcGetDataChannelMaxPacketLifeTime(int dc);
@@ -96,14 +97,14 @@ DataChannel::DataChannel(int id) : mId(id), mConnected(false) {
 	mLabel = str;
 }
 
-DataChannel::~DataChannel() { close(); }
+DataChannel::~DataChannel() {
+	close();
+	rtcDeleteDataChannel(mId);
+}
 
 void DataChannel::close() {
 	mConnected = false;
-	if (mId) {
-		rtcDeleteDataChannel(mId);
-		mId = 0;
-	}
+	rtcCloseDataChannel(mId);
 }
 
 bool DataChannel::send(message_variant message) {


### PR DESCRIPTION
This PR introduces a separate `rtcCloseDataChannel()` function to trigger `onClosed()` also when `close()` is called.